### PR TITLE
build: node v8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   test:
     docker:
-      - image: circleci/node:10
+      - image: circleci/node:8
     steps:
       - checkout
       - run:
@@ -25,7 +25,7 @@ jobs:
 
   build:
     docker:
-      - image: circleci/node:10
+      - image: circleci/node:8
     steps:
       - checkout
       - run: yarn
@@ -33,7 +33,7 @@ jobs:
 
   release:
     docker:
-      - image: circleci/node:10
+      - image: circleci/node:8
     steps:
       - checkout
       - run: yarn

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "**/*"
   ],
   "engines": {
-    "node": ">=10"
+    "node": ">=8"
   },
   "scripts": {
     "build": "pegjs --optimize size src/grammar.pegjs && sl-scripts build",


### PR DESCRIPTION
Spectral aims to support Node.js 8.x.x.
https://github.com/stoplightio/spectral/pull/232

@marbemac could we run stoplight/path against Node 8, 10 and 12 on CI, similarly to what Spectral does?
I doubt we'll ever encounter any significant inconsistency, but better safe than sorry. 