### PR TITLE
feat: basename now supports that optional second parameter

### DIFF
--- a/src/__tests__/basename.spec.ts
+++ b/src/__tests__/basename.spec.ts
@@ -11,7 +11,7 @@ describe('posix basename', () => {
     ${'////'}          | ${''}
     ${'//a'}           | ${'a'}
     ${'foo'}           | ${'foo'}
-  `('computes dirname of $path', ({ path, expected }) => {
+  `('computes basename of $path', ({ path, expected }) => {
     expect(basename(path)).toBe(expected);
   });
 });
@@ -50,7 +50,21 @@ describe('win32 basename', () => {
     ${'\\\\unc\\share\\foo\\bar\\baz'}   | ${'baz'}
     ${'\\\\unc\\share\\foo\\bar\\baz.x'} | ${'baz.x'}
     ${'foo'}                             | ${'foo'}
-  `('computes dirname of $path', ({ path, expected }) => {
+  `('computes basename of $path', ({ path, expected }) => {
     expect(basename(path)).toBe(expected);
+  });
+});
+
+describe('basename with removeExtension arg', () => {
+  it.each`
+    path               | removeExtension | expected
+    ${'/a/b/foo.json'} | ${'.json'}      | ${'foo'}
+    ${'/a/b/foo.txt'}  | ${'.json'}      | ${'foo.txt'}
+    ${'/a/b/foo.json'} | ${true}         | ${'foo'}
+    ${'/a/b/foo.txt'}  | ${true}         | ${'foo'}
+    ${'/a/b/foo.json'} | ${false}        | ${'foo.json'}
+    ${'/a/b/foo.txt'}  | ${false}        | ${'foo.txt'}
+  `('computes basename of $path, $removeExtension', ({ path, removeExtension, expected }) => {
+    expect(basename(path, removeExtension)).toBe(expected);
   });
 });

--- a/src/basename.ts
+++ b/src/basename.ts
@@ -2,10 +2,10 @@ import { normalizeParsed } from './normalize';
 import { parse } from './parse';
 import { parseBase } from './parseBase';
 
-export const basename = (path: string) => {
+export const basename = (path: string, removeExtension?: string | boolean) => {
   const parsed = normalizeParsed(parse(path));
   const base = parsed.path.pop();
   if (!base) return '';
   const { name, ext } = parseBase(base);
-  return `${name}${ext}`;
+  return removeExtension === true || removeExtension === ext ? name : `${name}${ext}`;
 };


### PR DESCRIPTION
>> Shall we support optional ext argument?
>
> I've never found it useful in practice.

Of course, now I want it, so I can more easily transform `/path/foo.txt` into `/path/foo-2.txt`.

The Node `path` behavior is silly though, because it expects you to know the extension ahead of time. So I "enhanced" it so that instead of

```js
basename(filePath, extname(filePath))
```

you can do
```js
basename(filePath, true)
```