### PR TITLE
fix: srn extensions

### DIFF
--- a/src/__tests__/srn.spec.ts
+++ b/src/__tests__/srn.spec.ts
@@ -37,6 +37,17 @@ describe('deserializeSrn', () => {
       ext: '.yml',
     });
   });
+
+  it('should work deserialize file node srns with dot in uri path', () => {
+    expect(deserializeSrn('sl/org/project/reference/stoplight/openapi.v1.yaml/paths/~1nodes.get/get')).toEqual({
+      shortcode: 'sl',
+      orgSlug: 'org',
+      projectSlug: 'project',
+      uri: '/reference/stoplight/openapi.v1.yaml/paths/~1nodes.get/get',
+      file: 'openapi.v1.yaml',
+      ext: '.yaml',
+    });
+  });
 });
 
 describe('serializeSrn', () => {

--- a/src/__tests__/srn.spec.ts
+++ b/src/__tests__/srn.spec.ts
@@ -26,6 +26,17 @@ describe('deserializeSrn', () => {
       ext: '.yml',
     });
   });
+
+  it('should work deserialize file node srns', () => {
+    expect(deserializeSrn('sl/org/project/reference/todos/openapi.yml/components/schemas/pet')).toEqual({
+      shortcode: 'sl',
+      orgSlug: 'org',
+      projectSlug: 'project',
+      uri: '/reference/todos/openapi.yml/components/schemas/pet',
+      file: 'openapi.yml',
+      ext: '.yml',
+    });
+  });
 });
 
 describe('serializeSrn', () => {

--- a/src/__tests__/srn.spec.ts
+++ b/src/__tests__/srn.spec.ts
@@ -1,14 +1,14 @@
 import { deserializeSrn, serializeSrn } from '../srn';
 
 describe('deserializeSrn', () => {
-  it('should work deserialize org srns', () => {
+  it('should work deserialize org srn', () => {
     expect(deserializeSrn('sl/org')).toEqual({
       shortcode: 'sl',
       orgSlug: 'org',
     });
   });
 
-  it('should work deserialize project srns', () => {
+  it('should work deserialize project srn', () => {
     expect(deserializeSrn('sl/org/project')).toEqual({
       shortcode: 'sl',
       orgSlug: 'org',
@@ -16,7 +16,7 @@ describe('deserializeSrn', () => {
     });
   });
 
-  it('should work deserialize node srns', () => {
+  it('should work deserialize node srn', () => {
     expect(deserializeSrn('sl/org/project/reference/todos/openapi.yml')).toEqual({
       shortcode: 'sl',
       orgSlug: 'org',
@@ -27,7 +27,18 @@ describe('deserializeSrn', () => {
     });
   });
 
-  it('should work deserialize file node srns', () => {
+  it('should work deserialize node srn two dots in file', () => {
+    expect(deserializeSrn('sl/org/project/reference/todos/openapi.v1.yml')).toEqual({
+      shortcode: 'sl',
+      orgSlug: 'org',
+      projectSlug: 'project',
+      uri: '/reference/todos/openapi.v1.yml',
+      file: 'openapi.v1.yml',
+      ext: '.yml',
+    });
+  });
+
+  it('should work deserialize node srn with extended uri parts', () => {
     expect(deserializeSrn('sl/org/project/reference/todos/openapi.yml/components/schemas/pet')).toEqual({
       shortcode: 'sl',
       orgSlug: 'org',
@@ -38,7 +49,7 @@ describe('deserializeSrn', () => {
     });
   });
 
-  it('should work deserialize file node srns with dot in uri path', () => {
+  it('should work deserialize file node srn with dot in uri path', () => {
     expect(deserializeSrn('sl/org/project/reference/stoplight/openapi.v1.yaml/paths/~1nodes.get/get')).toEqual({
       shortcode: 'sl',
       orgSlug: 'org',

--- a/src/__tests__/srn.spec.ts
+++ b/src/__tests__/srn.spec.ts
@@ -49,7 +49,7 @@ describe('deserializeSrn', () => {
     });
   });
 
-  it('should work deserialize file node srn with dot in uri path', () => {
+  it('should work deserialize node srn with dot in uri path', () => {
     expect(deserializeSrn('sl/org/project/reference/stoplight/openapi.v1.yaml/paths/~1nodes.get/get')).toEqual({
       shortcode: 'sl',
       orgSlug: 'org',

--- a/src/srn.ts
+++ b/src/srn.ts
@@ -1,5 +1,4 @@
-import { basename } from './basename';
-import { extname } from './extname';
+import { parseBase } from './parseBase';
 
 export interface IDeserializedSrn {
   shortcode: string;
@@ -18,8 +17,11 @@ export function deserializeSrn(srn: string): IDeserializedSrn {
   let file;
   let ext;
   if (uri) {
-    ext = extname(uri);
-    file = basename(uri);
+    file = uriParts.find(part => part.includes('.'));
+
+    if (file) {
+      ext = parseBase(file).ext;
+    }
   }
 
   return {


### PR DESCRIPTION
There was an issue where srns that referenced anything passed just a file were not getting deserialized correctly example
```
  srn:
   'gh/stoplightio/studio-demo/reference/petstore/openapi.v1.yaml/paths/~1pets/post',
  deserialized:
   { shortcode: 'gh',
     orgSlug: 'stoplightio',
     projectSlug: 'studio-demo',
     uri: '/reference/petstore/openapi.v1.yaml/paths/~1pets/post',
     file: 'post',
     ext: '' } }
```

Now it works
```
  srn:
   'gh/stoplightio/studio-demo/reference/petstore/openapi.v1.yaml/paths/~1pets/post',
  deserialized:
   { shortcode: 'gh',
     orgSlug: 'stoplightio',
     projectSlug: 'studio-demo',
     uri: '/reference/petstore/openapi.v1.yaml/paths/~1pets/post',
     file: 'openapi.v1.yaml',
     ext: 'yaml' } }
```
