### PR TITLE
fix: recognize windows drive letters with a leading slash, like '/C:/'

### DIFF
--- a/src/__tests__/normalize.spec.ts
+++ b/src/__tests__/normalize.spec.ts
@@ -12,9 +12,11 @@ describe('normalize', () => {
 
   describe('normalizes capitalization of Windows drive letters', () => {
     it.each`
-      path              | result
-      ${'C:\\foo\\bar'} | ${'c:/foo/bar'}
-      ${'/C:/foo/bar'}  | ${'c:/foo/bar'}
+      path                    | result
+      ${'C:\\foo\\bar'}       | ${'c:/foo/bar'}
+      ${'/C:/foo/bar'}        | ${'c:/foo/bar'}
+      ${'file:///C:/foo/bar'} | ${'c:/foo/bar'}
+      ${'file://C:/foo/bar'}  | ${'c:/foo/bar'}
     `("normalize('$path')", ({ path, result }) => {
       expect(normalize(path)).toEqual(result);
     });

--- a/src/__tests__/normalize.spec.ts
+++ b/src/__tests__/normalize.spec.ts
@@ -10,6 +10,16 @@ describe('normalize', () => {
     });
   });
 
+  describe('normalizes capitalization of Windows drive letters', () => {
+    it.each`
+      path              | result
+      ${'C:\\foo\\bar'} | ${'c:/foo/bar'}
+      ${'/C:/foo/bar'}  | ${'c:/foo/bar'}
+    `("normalize('$path')", ({ path, result }) => {
+      expect(normalize(path)).toEqual(result);
+    });
+  });
+
   describe('ignores POSIX slashes', () => {
     it.each`
       path        | result

--- a/src/__tests__/startsWithWindowsDrive.spec.ts
+++ b/src/__tests__/startsWithWindowsDrive.spec.ts
@@ -1,7 +1,7 @@
 import { startsWithWindowsDrive } from '../';
 
 describe('startsWithWindowsDrive', () => {
-  it.each(['c:\\foo\\bar.json', 'c:\\', 'c:/', 'c:/foo/bar.json', 'c:\\', 'Z:\\', 'A:/'])(
+  it.each(['c:\\foo\\bar.json', 'c:\\', 'c:/', 'c:/', '/C:/', '/C:\\', 'c:/foo/bar.json', 'c:\\', 'Z:\\', 'A:/'])(
     'recognizes driver letter in %s',
     filepath => {
       expect(startsWithWindowsDrive(filepath)).toBe(true);

--- a/src/grammar.pegjs
+++ b/src/grammar.pegjs
@@ -75,20 +75,20 @@ AbsolutePath
 }
 
   Root
-    = PosixRoot
-    / WindowsRoot
+    = WindowsRoot
+    / PosixRoot
+
+    WindowsRoot
+      = Sep ? drive:[A-Za-z] ":" Sep {
+        return {
+          drive: drive.toLowerCase() + ':'
+        }
+      }
 
     PosixRoot
       = Sep {
         return {
           drive: null
-        }
-      }
-
-    WindowsRoot
-      = drive:[A-Za-z] ":" Sep {
-        return {
-          drive: drive.toLowerCase() + ':'
         }
       }
 


### PR DESCRIPTION
Needed for https://github.com/stoplightio/platform-internal/pull/3760

This is useful in Electron where we have a relative URL `../worker/index.js` that gets resolved by the render process as `file:///C:/blaw/blaw/worker/index.js` and we need to normalize and recognize that URL to know to open it in the background window instead of in a external browser, and the obvious solution wasn't working because `file:///C:/` gots treated as a Linux path because of the third `/` and we lowercase windows drive letters in `format` but we don't lowercase a linux folder called `/C:/` and long story short this fixes it.

I added an optional leading slash for windows paths in front of the drive letter.