### PR TITLE
feat: recognize Stoplight protocol

### DIFF
--- a/src/__tests__/isAbsolute.spec.ts
+++ b/src/__tests__/isAbsolute.spec.ts
@@ -14,6 +14,7 @@ describe('isAbsolute', () => {
     '/var/bin.d',
     'http://example.com/is/absolute',
     'https://stoplight.io',
+    'stoplight://resources/overrides/abc',
     'file:///this/is/also/absolute',
     'file://c:/and/this/is/../absolute',
   ])('treats %s path as absolute', filepath => {

--- a/src/__tests__/isStoplightURI.spec.ts
+++ b/src/__tests__/isStoplightURI.spec.ts
@@ -1,0 +1,31 @@
+import { isStoplightURI } from '../isStoplightURI.js';
+
+describe('isStoplightURI', () => {
+  it.each(['stoplight://resources/overrides/abc', 'stoplight://some-resource'])(
+    'treats %s path as a Stoplight URI',
+    filepath => {
+      expect(isStoplightURI(filepath)).toBe(true);
+    },
+  );
+
+  it.each([
+    'http://example.com/is/absolute',
+    'https://stoplight.io',
+    '\\foo\\bar.json',
+    'c:\\foo\\bar.json',
+    'c:\\',
+    'c:/',
+    'c:/foo/bar.json',
+    '/home/test',
+    '/',
+    '//',
+    '/var/lib/test/',
+    '/var/bin.d',
+    'foo/bar',
+    'test',
+    '',
+    'file:///this/is/also/absolute',
+  ])('does treat %s path as a Stoplight URI', filepath => {
+    expect(isStoplightURI(filepath)).toBe(false);
+  });
+});

--- a/src/__tests__/isURL.spec.ts
+++ b/src/__tests__/isURL.spec.ts
@@ -1,0 +1,27 @@
+import { isURL } from '../isURL.js';
+
+describe('isURL', () => {
+  it.each(['http://example.com/is/absolute', 'https://stoplight.io'])('treats %s path as an URL', filepath => {
+    expect(isURL(filepath)).toBe(true);
+  });
+
+  it.each([
+    'stoplight://resources/overrides/abc',
+    '\\foo\\bar.json',
+    'c:\\foo\\bar.json',
+    'c:\\',
+    'c:/',
+    'c:/foo/bar.json',
+    '/home/test',
+    '/',
+    '//',
+    '/var/lib/test/',
+    '/var/bin.d',
+    'foo/bar',
+    'test',
+    '',
+    'file:///this/is/also/absolute',
+  ])('does treat %s path as an URL', filepath => {
+    expect(isURL(filepath)).toBe(false);
+  });
+});

--- a/src/grammar.pegjs
+++ b/src/grammar.pegjs
@@ -32,6 +32,7 @@ RemotePath
   RemoteProtocol
     = HttpProtocol
     / HttpsProtocol
+    / StoplightProtocol
 
     HttpProtocol
       = raw:"http://"i {
@@ -41,7 +42,12 @@ RemotePath
     HttpsProtocol
       = raw:"https://"i {
       return 'https'
-    } 
+    }
+
+    StoplightProtocol
+      = raw:"stoplight://"i {
+      return 'stoplight'
+    }
     
   Origin
     = $ NotSep+

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ export * from './dirname.js';
 export * from './extname.js';
 export * from './format.js';
 export * from './isAbsolute.js';
+export * from './isStoplightURI.js';
 export * from './isURL.js';
 export * from './join.js';
 export { normalize } from './normalize.js';

--- a/src/isStoplightURI.ts
+++ b/src/isStoplightURI.ts
@@ -1,0 +1,6 @@
+import { parse } from './parse.js';
+
+export function isStoplightURI(filepath: string) {
+  const parsed = parse(filepath);
+  return parsed.protocol === 'stoplight';
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
 export interface IPath {
-  protocol: 'file' | 'http' | 'https' | null;
+  protocol: 'file' | 'http' | 'https' | 'stoplight' | null;
   origin: string | null;
   absolute: boolean;
   drive: string | null;


### PR DESCRIPTION
`isAbsolute` needs to recognize `stoplight://` in order for certain utils from `@stoplight/json` to work properly.
Besides that, I added `isStoplightURI` function one can use in platform-internal / ref-resolver code as needed.

I was a bit torn when it comes to updating `isURL` and kept it as is for now.
