### PR TITLE
fix: remove type from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "url": "https://github.com/stoplightio/path"
   },
   "license": "Apache-2.0",
-  "type": "commonjs",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/types/index.d.ts",


### PR DESCRIPTION
WP5 doesn't like it. 
The change is already applied here https://github.com/stoplightio/platform-internal/pull/19101